### PR TITLE
Add paho-mqtt as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     fedora-messaging
     copr-messaging
     click
+    paho-mqtt
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The library is already installed in the image through
files/install-deps.yaml, but was missing from setup.cfg, which caused
installations through `pip` to be broken.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>