### PR TITLE
Log filtering sub-topics as 'info'

### DIFF
--- a/packit_service_centosmsg/consumer.py
+++ b/packit_service_centosmsg/consumer.py
@@ -63,7 +63,7 @@ class Consumerino(mqtt.Client):
         logger.info(f"Received a message on topic: {msg.topic}")
         subtopic = msg.topic.split("/", 1)[-1].split(".", 1)[0]
         if self.subtopics and subtopic not in self.subtopics:
-            logger.debug(
+            logger.info(
                 f"Ignore message: Subtopic {subtopic!r} not in {self.subtopics!r}."
             )
             return


### PR DESCRIPTION
So that when logging is set to 'info' level it's clearly visible which
messages are dropped in the consumer and which ones create a task for
Packit Service.

Fixes #6.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>