### PR TITLE
Support AWS SQS as a Celery broker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,22 +4,24 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.8
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+    rev: 2.1.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
@@ -34,7 +36,7 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/packit-service/pre-commit-hooks
-    rev: master
+    rev: 76dd54a98306a9f6ecf6672aa7687d6f07091c4e
     hooks:
       - id: check-rebase
         args:

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,5 @@ run:
 		-v $(CURDIR)/packit_service_centosmsg:/usr/local/lib/python3.8/site-packages/packit_service_centosmsg:ro,Z \
 		-v $(CURDIR)/secrets:/secrets:ro,Z \
 		-e LOG_LEVEL=DEBUG \
+		-e REDIS_SERVICE_HOST=redis \
 		$(IMAGE)

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -8,6 +8,8 @@
           - python3-celery
           - python3-redis
           - redis # redis-cli
+          - python3-boto3 # AWS SDK
+          - python3-pycurl # ^
           - python3-click
           - git # setuptools-scm
           - python3-setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = packit-service-centosmsg
-url = n/a
+url = https://github.com/packit/packit-service-centosmsg
 description = Centos messaging consumer for packit-service
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -32,7 +32,7 @@ setup_requires =
     setuptools_scm_git_archive
 
 install_requires =
-    celery[redis]
+    celery[redis,sqs]
     click
     paho-mqtt
 


### PR DESCRIPTION
We use AWS SQS if both `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` are set.
It they are not, fall back to redis.
By default (if `QUEUE_NAME_PREFIX` is not set) we use `packit-$DEPLOYMENT-` queue prefix,
i.e. we have `packit-stg-celery` and `packit-prod-celery` queues.