### PR TITLE
Don't require sqs

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -8,8 +8,6 @@
           - python3-celery
           - python3-redis
           - redis # redis-cli
-          - python3-boto3 # AWS SDK
-          - python3-pycurl # ^
           - python3-click
           - git # setuptools-scm
           - python3-setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ setup_requires =
     setuptools_scm_git_archive
 
 install_requires =
-    celery[redis,sqs]
+    celery[redis]
     click
     paho-mqtt
 


### PR DESCRIPTION
We don't (and won't) need it and there's some strange behavior when [building this on F34](https://github.com/packit/packit-service-centosmsg/runs/3277923497).